### PR TITLE
Makes the docker reception config more resilient

### DIFF
--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -73,113 +73,130 @@
         </div>
         <div class="card-block collapse" id="config">
           <pre><code>
-  {{ range $project, $containers := groupByLabel $ "com.docker.compose.project" }}
-    {{ $host := replace "_host_.docker" "_host_" $project 1 }}
+{{ range $project, $containers := groupByLabel $ "com.docker.compose.project" }}
+  {{ $host := replace "_host_.docker" "_host_" $project 1 }}
+
+  ##
+  # {{ $project }} ({{ len $containers }} containers)
+  ##
+
+  {{ range $app, $containers := groupByLabel $containers "com.docker.compose.service" }}
+    {{ $app := trim $app }}
+    {{ $host := trim $host }}
 
     ##
-    # {{ $project }} ({{ len $containers }} containers)
+    # {{ $project }}.{{ $app }} ({{ len $containers }} containers)
     ##
 
-    {{ range $app, $containers := groupByLabel $containers "com.docker.compose.service" }}
-      {{ $app := trim $app }}
-      {{ $host := trim $host }}
+    {{ if eq $app "app" }}
+      upstream {{ $host }} {
+    {{ else }}
+      upstream {{ $app }}.{{ $host }} {
+    {{ end }}
+        {{/* random server entry, because at least one server has to be defined to be non-backup. */}}
+        server 127.0.0.1:1 down;
+      {{ range $index, $value := $containers }}
+        {{ $addrLen := len $value.Addresses }}
+        {{ $network := index $value.Networks 0 }}
 
-      ##
-      # {{ $project }}.{{ $app }} ({{ len $containers }} containers)
-      ##
+        # {{$value.Name}}
+        # Addresses: {{$addrLen}}
+
+        {{/* If only 1 port exposed, use that */}}
+        {{ if eq $addrLen 1 }}
+          {{ with $address := index $value.Addresses 0 }}
+            # Only one port
+            # server {{ $network.IP }}:{{ $address.Port }};
+            server 127.0.0.1:{{ $address.HostPort }};
+          {{ end }}
+
+        {{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var */}}
+        {{ else if $value.Env.VIRTUAL_PORT }}
+          {{ range $i, $address := $value.Addresses }}
+            {{ if eq $address.Port $value.Env.VIRTUAL_PORT }}
+              # Port from VIRTUAL_PORT env var
+              # server {{ $network.IP }}:{{ $address.Port }};
+              server 127.0.0.1:{{ $address.HostPort }};
+            {{ end }}
+          {{ end }}
+
+        {{/* Else default to standard web port 80 */}}
+        {{ else }}
+          {{ range $i, $address := $value.Addresses }}
+            {{ if $address.HostPort }}
+              {{ if eq $address.Port "80" }}
+                # Port is 80
+                # server {{ $network.IP }}:{{ $address.Port }};
+                server 127.0.0.1:{{ $address.HostPort }};
+              {{ else if eq $address.Port "8080" }}
+                # Port is 8080
+                # server {{ $network.IP }}:{{ $address.Port }};
+                server 127.0.0.1:{{ $address.HostPort }};
+              {{ else if eq $address.Port "3000" }}
+                # Port is 3000
+                # server {{ $network.IP }}:{{ $address.Port }};
+                server 127.0.0.1:{{ $address.HostPort }};
+              {{ end }}
+            {{ end }}
+          {{ end }}
+        {{ end }}
+
+        {{/* adds all HostPorts as backup servers */}}
+        {{ range $i, $address := $value.Addresses }}
+          {{ if $address.HostPort }}
+            # server {{ $network.IP }}:{{ $address.Port }};
+            server 127.0.0.1:{{ $address.HostPort }} backup;
+          {{ end }}
+        {{ end }}
+      {{ end }}
+      }
+
+    server {
+      listen 80;
+
+      gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
 
       {{ if eq $app "app" }}
-        upstream {{ $host }} {
+      server_name {{ $host }} *.{{ $host }};
       {{ else }}
-        upstream {{ $app }}.{{ $host }} {
+      server_name {{ $app }}.{{ $host }} *.{{ $app }}.{{ $host }};
       {{ end }}
-        {{ range $index, $value := $containers }}
-          {{ $addrLen := len $value.Addresses }}
-          {{ $network := index $value.Networks 0 }}
+      proxy_buffering off;
+      # error_log /proc/self/fd/2;
+      # access_log /proc/self/fd/1;
 
-          # {{$value.Name}}
-          # Addresses: {{$addrLen}}
-
-          {{/* If only 1 port exposed, use that */}}
-          {{ if eq $addrLen 1 }}
-            {{ with $address := index $value.Addresses 0 }}
-              # server {{ $network.IP }}:{{ $address.Port }};
-              server localhost:{{ $address.HostPort }};
-            {{ end }}
-
-          {{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var */}}
-          {{ else if $value.Env.VIRTUAL_PORT }}
-            {{ range $i, $address := $value.Addresses }}
-              {{ if eq $address.Port $value.Env.VIRTUAL_PORT }}
-                # server {{ $network.IP }}:{{ $address.Port }};
-                server localhost:{{ $address.HostPort }};
-              {{ end }}
-            {{ end }}
-
-          {{/* Else default to standard web port 80 */}}
-          {{ else }}
-            {{ range $i, $address := $value.Addresses }}
-              {{ if eq $address.Port "80" }}
-                # server {{ $network.IP }}:{{ $address.Port }};
-                server localhost:{{ $address.HostPort }};
-              {{ else if eq $address.Port "8080" }}
-                # server {{ $network.IP }}:{{ $address.Port }};
-                server localhost:{{ $address.HostPort }};
-              {{ else if eq $address.Port "3000" }}
-                # server {{ $network.IP }}:{{ $address.Port }};
-                server localhost:{{ $address.HostPort }};
-              {{ end }}
-            {{ end }}
-          {{ end }}
-        {{ end }}
-      }
-
-      server {
-        listen 80;
-
-        gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
-
-
+      location / {
         {{ if eq $app "app" }}
-        server_name {{ $host }} *.{{ $host }};
+          proxy_pass http://{{ $host }};
         {{ else }}
-        server_name {{ $app }}.{{ $host }} *.{{ $app }}.{{ $host }};
+          proxy_pass http://{{ $app }}.{{ $host }};
         {{ end }}
-        proxy_buffering off;
-        # error_log /proc/self/fd/2;
-        # access_log /proc/self/fd/1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
 
-        location / {
-          {{ if eq $app "app" }}
-            proxy_pass http://{{ $host }};
-          {{ else }}
-            proxy_pass http://{{ $app }}.{{ $host }};
-          {{ end }}
-          proxy_set_header Host $http_host;
-          proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header X-Forwarded-Proto $scheme;
-
-          # HTTP 1.1 support
-          proxy_http_version 1.1;
-          proxy_set_header Connection "";
-        }
+        # HTTP 1.1 support
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
       }
-    {{ end }}
-  {{ end }}
-
-  # default server
-  server {
-    listen 80 default_server;
-    server_name reception.dev;
-    # error_log /proc/self/fd/2;
-    # access_log /proc/self/fd/1;
-
-    location / {
-        root   html;
-        index  index.html index.htm;
     }
+  {{ end }}
+{{ end }}
+
+# default server
+server {
+  listen 80 default_server;
+  server_name reception.docker;
+  # error_log /proc/self/fd/2;
+  # access_log /proc/self/fd/1;
+
+  location / {
+      root   html;
+      index  index.html index.htm;
   }
+}
           </code></pre>
         </div>
       </div>

--- a/nginx.conf.tmpl
+++ b/nginx.conf.tmpl
@@ -18,6 +18,8 @@
     {{ else }}
       upstream {{ $app }}.{{ $host }} {
     {{ end }}
+        {{/* random server entry, because at least one server has to be defined to be non-backup. */}}
+        server 127.0.0.1:1 down;
       {{ range $index, $value := $containers }}
         {{ $addrLen := len $value.Addresses }}
         {{ $network := index $value.Networks 0 }}
@@ -28,6 +30,7 @@
         {{/* If only 1 port exposed, use that */}}
         {{ if eq $addrLen 1 }}
           {{ with $address := index $value.Addresses 0 }}
+            # Only one port
             # server {{ $network.IP }}:{{ $address.Port }};
             server 127.0.0.1:{{ $address.HostPort }};
           {{ end }}
@@ -36,6 +39,7 @@
         {{ else if $value.Env.VIRTUAL_PORT }}
           {{ range $i, $address := $value.Addresses }}
             {{ if eq $address.Port $value.Env.VIRTUAL_PORT }}
+              # Port from VIRTUAL_PORT env var
               # server {{ $network.IP }}:{{ $address.Port }};
               server 127.0.0.1:{{ $address.HostPort }};
             {{ end }}
@@ -44,20 +48,33 @@
         {{/* Else default to standard web port 80 */}}
         {{ else }}
           {{ range $i, $address := $value.Addresses }}
-            {{ if eq $address.Port "80" }}
-              # server {{ $network.IP }}:{{ $address.Port }};
-              server 127.0.0.1:{{ $address.HostPort }};
-            {{ else if eq $address.Port "8080" }}
-              # server {{ $network.IP }}:{{ $address.Port }};
-              server 127.0.0.1:{{ $address.HostPort }};
-            {{ else if eq $address.Port "3000" }}
-              # server {{ $network.IP }}:{{ $address.Port }};
-              server 127.0.0.1:{{ $address.HostPort }};
+            {{ if $address.HostPort }}
+              {{ if eq $address.Port "80" }}
+                # Port is 80
+                # server {{ $network.IP }}:{{ $address.Port }};
+                server 127.0.0.1:{{ $address.HostPort }};
+              {{ else if eq $address.Port "8080" }}
+                # Port is 8080
+                # server {{ $network.IP }}:{{ $address.Port }};
+                server 127.0.0.1:{{ $address.HostPort }};
+              {{ else if eq $address.Port "3000" }}
+                # Port is 3000
+                # server {{ $network.IP }}:{{ $address.Port }};
+                server 127.0.0.1:{{ $address.HostPort }};
+              {{ end }}
             {{ end }}
           {{ end }}
         {{ end }}
+
+        {{/* adds all HostPorts as backup servers */}}
+        {{ range $i, $address := $value.Addresses }}
+          {{ if $address.HostPort }}
+            # server {{ $network.IP }}:{{ $address.Port }};
+            server 127.0.0.1:{{ $address.HostPort }} backup;
+          {{ end }}
+        {{ end }}
       {{ end }}
-    }
+      }
 
     server {
       listen 80;


### PR DESCRIPTION
Adds some hacks to the nginx config to have all exposed ports as upstream hosts, even when none matches our 'default' criteria (only one port is exposed, the `VIRTUAL_PORT` environment variable is defined or the exposed port is one of 80, 8080 or 3000).